### PR TITLE
Fix/hide border as well as drawer on multi monitor setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ go.work.sum
 # env file
 .env
 
+# Release notes staged for git tag annotation (passed via `git tag -a -F`)
+release-notes.md
+
 # Editor/IDE
 # .idea/
 .vscode/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,3 +74,9 @@ nfpms:
 release:
   draft: false
   prerelease: auto
+  # The annotated tag's message body becomes the top of the release notes,
+  # followed by the auto-generated commit changelog. Write detailed notes with
+  # `git tag -a vX.Y.Z` (opens an editor) or `git tag -a vX.Y.Z -F notes.md`.
+  # Lightweight tags (no -a/-m) leave this empty and fall back to the changelog.
+  header: |
+    {{ .TagBody }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,12 @@ It has two display backends:
 
 - Module: `github.com/dahui/z13gui`
 - Binary: `z13gui`
-- Repo: `/home/jeff/dev/z13gui`
 
 ## Companion project: z13ctl
 
-The `z13ctl` daemon lives at `/home/jeff/dev/z13rgb` (module `github.com/dahui/z13ctl`).
-Its `api/` submodule (`github.com/dahui/z13ctl/api`) is at `/home/jeff/dev/z13rgb/api/`
-and is also published at tag `api/v1.1.3` on GitHub.
+The `z13ctl` daemon (module `github.com/dahui/z13ctl`) is a sibling repo.
+Its `api/` submodule (`github.com/dahui/z13ctl/api`) is published at tag `api/v1.1.6`
+on GitHub.
 
 During local development, a `go.work` file in this repo (if present, gitignored) provides
 the local override. In production the `go.mod` imports the published tag.
@@ -66,18 +65,22 @@ contrib/
 
 - **Layer-shell** (KDE): `github.com/diamondburned/gotk4-layer-shell/pkg/gtk4layershell`
   (NOT `gtklayershell` which is GTK3). pkg-config name: `gtk4-layer-shell-0`.
-- **Anchor**: right edge only (`LayerShellEdgeRight`). No top/bottom anchor — compositor
-  centers the window vertically at natural height.
+- **Anchor**: right + top + bottom edges. Top/bottom margins set to 5% of screen height
+  on realize. The surface is pinned to its monitor via `SetMonitor` to prevent bleed
+  onto adjacent displays.
 - **Keyboard mode**: `LayerShellKeyboardModeOnDemand` — gets focus when visible.
 - **Animation**: layer-shell right-margin animation (`gtk4layershell.SetMargin`).
   `margin=0` → on-screen; `margin=-320` → off-screen to the right.
   Avoids GTK Revealer which causes pixman errors and smearing artifacts in Wayland.
 - **Window visibility**: window is kept `SetVisible(true)` at all times after creation.
-  It's "hidden" by setting margin = -320 (off-screen), not by destroying/hiding the surface.
-  This prevents the ghost-surface artifact that KDE Plasma shows when remapping a surface.
+  It's "hidden" by setting margin = -(width-1) (off-screen) and opacity = 0, not by
+  destroying/hiding the surface. This prevents the ghost-surface artifact that KDE Plasma
+  shows when remapping a surface. The 1px margin keeps the surface in KWin's composited
+  output for damage tracking; opacity 0 makes the sliver invisible to the user.
 - **Width**: `SetSizeRequest(320, -1)`. Height is natural (content-driven, scrolled).
-- **Slide animation**: smoothstep timer loop via `glib.TimeoutAdd(16, ...)`.
-  Tracks current margin in `Window.margin` field; generation counter prevents overlapping.
+- **Slide animation**: smoothstep easing via `AddTickCallback` (VSync-synced).
+  Tracks current margin in `Backend.margin` field; generation counter prevents overlapping.
+  Show sets opacity=1 before sliding in; Hide sets opacity=0 after sliding out.
 - **State source of truth**: daemon is the source of truth. On show, `api.SendGetState()`
   is called and `syncState()` updates widgets. Widget signals are suppressed during sync
   via `Window.syncing bool`.
@@ -98,9 +101,12 @@ contrib/
 - **Profile selector**: buttons (`gtk.Button`), stored in
   `w.profileBtns map[string]*gtk.Button`. Not DropDown (popup broken in gamescope).
 - **Focus-loss dismiss** (layer-shell): `EventControllerMotion` tracks `pointerInside`
-  on the backend. On `notify::is-active` focus loss: if pointer is inside, the drop is
-  spurious (KDE Plasma briefly drops focus during keyboard-mode transitions) → ignored.
+  on the backend. On `notify::is-active` focus loss: if within 500ms of Show, ignored
+  (compositor settle time for keyboard-mode transition). If pointer is inside, the drop
+  is spurious (KDE Plasma briefly drops focus during keyboard-mode transitions) → ignored.
   If pointer is outside, user clicked elsewhere → dismiss after 200ms confirmation delay.
+  Do NOT add a `focusedSinceShow` guard — it causes first-show dismiss regression on KDE
+  where the compositor drops focus during keyboard-mode transition and never re-grants it.
   Escape key also dismisses in both backends.
 - **GTK_A11Y=none**: set in `main.go` and `contrib/z13gui.service`. Disables GTK4
   AT-SPI accessibility bridge, which sends D-Bus events on every widget state change.
@@ -148,6 +154,7 @@ Functions used:
 - `api.SendGetState() (bool, *api.State, error)` — fetch full daemon state on show
 - `api.Subscribe([]string{"gui-toggle"}) (<-chan string, func(), error)` — event stream
 - `api.SendApply(device, color1, color2, mode, speed string, brightness int) (bool, error)`
+- `api.SendOff(device string) (bool, error)` — turn off lighting for a device
 - `api.SendProfileSet(profile string) (bool, error)`
 - `api.SendBatteryLimitSet(limit int) (bool, error)`
 - `api.SendPanelOverdriveSet(value int) (bool, error)` — 0 or 1
@@ -176,7 +183,7 @@ type State struct {
     FanRPM             int   // fan1 speed in RPM
 }
 type LightingState struct {
-    Mode string; Color string; Color2 string
+    Enabled bool; Mode string; Color string; Color2 string
     Speed string; Brightness int
 }
 type TDPState struct {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,8 @@ contrib/
 - **Layer-shell** (KDE): `github.com/diamondburned/gotk4-layer-shell/pkg/gtk4layershell`
   (NOT `gtklayershell` which is GTK3). pkg-config name: `gtk4-layer-shell-0`.
 - **Anchor**: right + top + bottom edges. Top/bottom margins set to 5% of screen height
-  on realize. The surface is pinned to its monitor via `SetMonitor` to prevent bleed
-  onto adjacent displays.
+  on realize. The surface is pinned to its monitor via `SetMonitor` (helps wlroots
+  compositors clip overflow; KWin does NOT clip, see conditional fade below).
 - **Keyboard mode**: `LayerShellKeyboardModeOnDemand` — gets focus when visible.
 - **Animation**: layer-shell right-margin animation (`gtk4layershell.SetMargin`).
   `margin=0` → on-screen; `margin=-320` → off-screen to the right.
@@ -78,9 +78,17 @@ contrib/
   shows when remapping a surface. The 1px margin keeps the surface in KWin's composited
   output for damage tracking; opacity 0 makes the sliver invisible to the user.
 - **Width**: `SetSizeRequest(320, -1)`. Height is natural (content-driven, scrolled).
-- **Slide animation**: smoothstep easing via `AddTickCallback` (VSync-synced).
-  Tracks current margin in `Backend.margin` field; generation counter prevents overlapping.
-  Show sets opacity=1 before sliding in; Hide sets opacity=0 after sliding out.
+- **Show/hide animation**: smoothstep easing via `AddTickCallback` (VSync-synced),
+  with a shared `animGen` generation counter so a show cancels an in-flight hide
+  (and vice versa). Two paths, chosen per Show/Hide by `hasRightNeighbor()`:
+  - **No monitor to the right** → slide the right margin (`slideMargin`). Show sets
+    opacity=1 then slides in; Hide slides out then sets opacity=0 (hides the 1px
+    sliver on the primary's own right edge).
+  - **A monitor to the right** → fade in place (`fadeOpacity`) at margin 0, fully on
+    the primary, then park the transparent surface off-screen. A rightward slide
+    would otherwise bleed onto that monitor because KWin doesn't clip layer-surface
+    overflow to the assigned output. `Backend.margin`/`Backend.opacity` track current
+    state; use `setMargin`/`setOpacity` to keep them in sync.
 - **State source of truth**: daemon is the source of truth. On show, `api.SendGetState()`
   is called and `syncState()` updates widgets. Widget signals are suppressed during sync
   via `Window.syncing bool`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -102,7 +102,7 @@ system package manager first.
 
 === "From source"
 
-    Requires Go 1.23+, CGO enabled, and GTK4 development libraries.
+    Requires Go 1.25+, CGO enabled, and GTK4 development libraries.
 
     **Arch Linux:**
 

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/dahui/z13ctl/api v1.1.6
 	github.com/diamondburned/gotk4-layer-shell/pkg v0.0.0-20240109211357-6efa9f6dc438
 	github.com/diamondburned/gotk4/pkg v0.3.1
-	github.com/holoplot/go-evdev v0.0.0-20250804134636-ab1d56a1fe83
+	github.com/holoplot/go-evdev v0.0.0-20260504100651-66d1748fe847
 )
 
 require (
 	github.com/KarpelesLab/weak v0.1.1 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6 // indirect
-	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/holoplot/go-evdev v0.0.0-20250804134636-ab1d56a1fe83 h1:B+A58zGFuDrvEZpPN+yS6swJA0nzqgZvDzgl/OPyefU=
-github.com/holoplot/go-evdev v0.0.0-20250804134636-ab1d56a1fe83/go.mod h1:iHAf8OIncO2gcQ8XOjS7CMJ2aPbX2Bs0wl5pZyanEqk=
+github.com/holoplot/go-evdev v0.0.0-20260504100651-66d1748fe847 h1:1rQ5UQXFm02DXEtsIpotfA32WJ9KceS6t8w5K8QtFqc=
+github.com/holoplot/go-evdev v0.0.0-20260504100651-66d1748fe847/go.mod h1:iHAf8OIncO2gcQ8XOjS7CMJ2aPbX2Bs0wl5pZyanEqk=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
 github.com/josharian/native v1.1.0/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
 github.com/jsimonetti/rtnetlink/v2 v2.0.1 h1:xda7qaHDSVOsADNouv7ukSuicKZO7GgVUCXxpaIEIlM=
@@ -32,7 +32,7 @@ go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6 h1:lGdhQUN
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/net v0.46.0 h1:giFlY12I07fugqwPuWJi68oOnpfqFnJIJzaIIm2JVV4=
 golang.org/x/net v0.46.0/go.mod h1:Q9BGdFy1y4nkUwiLvT5qtyhAnEHgnQ/zd8PfU6nc210=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/gui/layershell/layershell.go
+++ b/internal/gui/layershell/layershell.go
@@ -32,8 +32,7 @@ type Backend struct {
 	animGen          uint64    // incremented to cancel in-flight animations
 	animating        bool      // true during show/hide slide animation
 	pointerInside    bool      // true when pointer is over the drawer surface
-	showTime         time.Time // when Show() was last called; used to ignore early focus loss
-	focusedSinceShow bool      // true once compositor grants focus after Show()
+	showTime time.Time // when Show() was last called; used to ignore early focus loss
 }
 
 // New creates a layer-shell backend. drawerWidth is the drawer panel width in pixels.
@@ -127,12 +126,11 @@ func (b *Backend) Configure(isVisible func() bool, onDismiss func()) {
 		active := b.appWin.IsActive()
 		vis := isVisible()
 		slog.Debug("focus changed", "is-active", active, "visible", vis,
-			"focusedSinceShow", b.focusedSinceShow, "pointerInside", b.pointerInside)
+			"pointerInside", b.pointerInside)
 		if active {
-			b.focusedSinceShow = true
 			return
 		}
-		if !vis || !b.focusedSinceShow {
+		if !vis {
 			return
 		}
 		if time.Since(b.showTime) < showSettleTime {
@@ -180,7 +178,6 @@ func (b *Backend) Show() {
 	slog.Debug("backend.Show", "startMargin", b.margin)
 	b.appWin.SetOpacity(1)
 	b.showTime = time.Now()
-	b.focusedSinceShow = false
 
 	gtk4layershell.SetKeyboardMode(b.gtkWin, gtk4layershell.LayerShellKeyboardModeOnDemand)
 	b.slideMargin(0, func() {

--- a/internal/gui/layershell/layershell.go
+++ b/internal/gui/layershell/layershell.go
@@ -34,7 +34,6 @@ type Backend struct {
 	pointerInside    bool      // true when pointer is over the drawer surface
 	showTime         time.Time // when Show() was last called; used to ignore early focus loss
 	focusedSinceShow bool      // true once compositor grants focus after Show()
-	startup          bool      // true until first Show() reveals the surface
 }
 
 // New creates a layer-shell backend. drawerWidth is the drawer panel width in pixels.
@@ -45,7 +44,6 @@ func New(appWin *gtk.ApplicationWindow, gtkWin *gtk.Window, drawerWidth int) *Ba
 		drawerWidth:  drawerWidth,
 		hiddenMargin: -(drawerWidth - 1),
 		margin:       -(drawerWidth - 1),
-		startup:      true,
 	}
 }
 
@@ -180,10 +178,7 @@ func (b *Backend) WrapContent(drawer gtk.Widgetter) gtk.Widgetter {
 // Show starts the slide-in animation using a smoothstep easing curve.
 func (b *Backend) Show() {
 	slog.Debug("backend.Show", "startMargin", b.margin)
-	if b.startup {
-		b.appWin.SetOpacity(1)
-		b.startup = false
-	}
+	b.appWin.SetOpacity(1)
 	b.showTime = time.Now()
 	b.focusedSinceShow = false
 
@@ -204,6 +199,7 @@ func (b *Backend) Hide() {
 	b.pointerInside = false // clear stale state; surface stays mapped off-screen
 	b.slideMargin(b.hiddenMargin, func() {
 		b.animating = false
+		b.appWin.SetOpacity(0)
 	})
 }
 

--- a/internal/gui/layershell/layershell.go
+++ b/internal/gui/layershell/layershell.go
@@ -26,13 +26,14 @@ type Backend struct {
 	appWin *gtk.ApplicationWindow
 	gtkWin *gtk.Window
 
-	drawerWidth      int
-	hiddenMargin     int
-	margin           int       // current right margin: 0=on-screen, hiddenMargin=1px visible
-	animGen          uint64    // incremented to cancel in-flight animations
-	animating        bool      // true during show/hide slide animation
-	pointerInside    bool      // true when pointer is over the drawer surface
-	showTime time.Time // when Show() was last called; used to ignore early focus loss
+	drawerWidth   int
+	hiddenMargin  int
+	margin        int       // current right margin: 0=on-screen, hiddenMargin=1px visible
+	opacity       float64   // current window opacity, tracked for fade interpolation
+	animGen       uint64    // incremented to cancel in-flight animations
+	animating     bool      // true during show/hide slide animation
+	pointerInside bool      // true when pointer is over the drawer surface
+	showTime      time.Time // when Show() was last called; used to ignore early focus loss
 }
 
 // New creates a layer-shell backend. drawerWidth is the drawer panel width in pixels.
@@ -85,7 +86,7 @@ func (b *Backend) Configure(isVisible func() bool, onDismiss func()) {
 	// Opacity starts at 0 so the surface is in KWin's composited output (for
 	// damage tracking) but invisible to the user. Show() sets opacity to 1.
 	b.appWin.SetVisible(true)
-	b.appWin.SetOpacity(0)
+	b.setOpacity(0)
 
 	// After the surface is mapped, poll until the compositor configures the
 	// actual width (which may exceed drawerWidth due to CSS borders/styling).
@@ -99,8 +100,7 @@ func (b *Backend) Configure(isVisible func() bool, onDismiss func()) {
 				return true // compositor hasn't configured yet, retry
 			}
 			b.hiddenMargin = -(w - 1)
-			b.margin = b.hiddenMargin
-			gtk4layershell.SetMargin(b.gtkWin, gtk4layershell.LayerShellEdgeRight, b.hiddenMargin)
+			b.setMargin(b.hiddenMargin)
 			return false
 		})
 	})
@@ -175,29 +175,45 @@ func (b *Backend) WrapContent(drawer gtk.Widgetter) gtk.Widgetter {
 
 // Show starts the slide-in animation using a smoothstep easing curve.
 func (b *Backend) Show() {
-	slog.Debug("backend.Show", "startMargin", b.margin)
-	b.appWin.SetOpacity(1)
+	slog.Debug("backend.Show", "startMargin", b.margin, "rightNeighbor", b.hasRightNeighbor())
 	b.showTime = time.Now()
 
 	gtk4layershell.SetKeyboardMode(b.gtkWin, gtk4layershell.LayerShellKeyboardModeOnDemand)
-	b.slideMargin(0, func() {
-		b.animating = false
-	})
+	if b.hasRightNeighbor() {
+		// A monitor sits to the right: a rightward slide-off would cross onto it
+		// while opaque (KWin does not clip layer-surface overflow to the assigned
+		// output). Fade in place at margin 0, fully on the primary instead.
+		b.setMargin(0)
+		b.setOpacity(0)
+		b.fadeOpacity(1, func() { b.animating = false })
+	} else {
+		b.setOpacity(1)
+		b.slideMargin(0, func() { b.animating = false })
+	}
 	b.appWin.Present()
 }
 
-// Hide starts the slide-out animation.
+// Hide starts the slide-out (or fade-out) animation.
 func (b *Backend) Hide() {
-	slog.Debug("backend.Hide", "startMargin", b.margin)
+	slog.Debug("backend.Hide", "startMargin", b.margin, "rightNeighbor", b.hasRightNeighbor())
 	if w := b.gtkWin.Width(); w > 0 {
 		b.hiddenMargin = -(w - 1)
 	}
 	gtk4layershell.SetKeyboardMode(b.gtkWin, gtk4layershell.LayerShellKeyboardModeNone)
 	b.pointerInside = false // clear stale state; surface stays mapped off-screen
-	b.slideMargin(b.hiddenMargin, func() {
-		b.animating = false
-		b.appWin.SetOpacity(0)
-	})
+	if b.hasRightNeighbor() {
+		// Fade out in place (margin 0, on the primary), then park the now-invisible
+		// surface off-screen. The drawer never crosses onto the right monitor.
+		b.fadeOpacity(0, func() {
+			b.animating = false
+			b.setMargin(b.hiddenMargin)
+		})
+	} else {
+		b.slideMargin(b.hiddenMargin, func() {
+			b.animating = false
+			b.setOpacity(0) // hide the 1px sliver on the primary's own right edge
+		})
+	}
 }
 
 // slideMargin animates b.margin from its current value to target over
@@ -240,6 +256,85 @@ func (b *Backend) slideMargin(target int, onDone func()) uint64 {
 	})
 
 	return gen
+}
+
+// setMargin sets the right margin and keeps b.margin in sync.
+func (b *Backend) setMargin(m int) {
+	b.margin = m
+	gtk4layershell.SetMargin(b.gtkWin, gtk4layershell.LayerShellEdgeRight, m)
+}
+
+// setOpacity sets the window opacity and keeps b.opacity in sync.
+func (b *Backend) setOpacity(o float64) {
+	b.opacity = o
+	b.appWin.SetOpacity(o)
+}
+
+// fadeOpacity animates the window opacity from its current value to target over
+// animDuration using smoothstep easing. onDone runs on the main thread when the
+// animation completes. Shares animGen with slideMargin so the two cancel each
+// other when a show interrupts a hide (or vice versa).
+func (b *Backend) fadeOpacity(target float64, onDone func()) {
+	b.animGen++
+	gen := b.animGen
+	b.animating = true
+	start := b.opacity
+	t0 := time.Now()
+
+	b.gtkWin.AddTickCallback(func(_ gtk.Widgetter, _ gdk.FrameClocker) bool {
+		if b.animGen != gen {
+			slog.Debug("fade cancelled", "gen", gen, "currentGen", b.animGen)
+			return false
+		}
+		t := float64(time.Since(t0)) / float64(animDuration)
+		if t >= 1.0 {
+			b.setOpacity(target)
+			b.invalidateSurface()
+			slog.Debug("fade complete", "gen", gen, "opacity", target)
+			if onDone != nil {
+				onDone()
+			}
+			return false
+		}
+		t = t * t * (3 - 2*t) // smoothstep
+		b.setOpacity(start + (target-start)*t)
+		b.invalidateSurface()
+		return true
+	})
+}
+
+// hasRightNeighbor reports whether any monitor sits to the right of the drawer's
+// monitor (vertically overlapping its band). When true, hiding by sliding the
+// surface rightward off the primary would bleed onto that monitor, so a fade is
+// used instead. Recomputed per Show/Hide so monitor hotplug is handled.
+func (b *Backend) hasRightNeighbor() bool {
+	surface := b.appWin.Surface()
+	if surface == nil {
+		return false
+	}
+	display := gdk.DisplayGetDefault()
+	if display == nil {
+		return false
+	}
+	self := display.MonitorAtSurface(surface)
+	if self == nil {
+		return false
+	}
+	g := self.Geometry()
+	rightEdge := g.X() + g.Width()
+	monitors := display.Monitors()
+	n := monitors.NItems()
+	for i := uint(0); i < n; i++ {
+		m, ok := monitors.Item(i).Cast().(*gdk.Monitor)
+		if !ok || m == nil {
+			continue
+		}
+		mg := m.Geometry()
+		if mg.X() >= rightEdge && mg.Y() < g.Y()+g.Height() && mg.Y()+mg.Height() > g.Y() {
+			return true
+		}
+	}
+	return false
 }
 
 // invalidateSurface forces both widget-level and GDK surface-level


### PR DESCRIPTION
## Summary

Brief description of the changes in this pull request.

## Changes

### Bug fixes

- **Drawer is fully hidden when closed, including on multi-monitor setups**
  (#4, #8). Once closed, the drawer is made transparent so it no longer leaves a
  thin sliver along the primary monitor's right edge (#8). On setups with a second
  monitor to the right, the drawer now fades in and out in place rather than
  sliding off the right edge, so it never appears on the adjacent display — neither
  as a lingering ghost nor a flash during the animation (#4). The v1.2.5 attempt to
  fix #4 by pinning the surface to its monitor was insufficient on KWin, which does
  not clip layer-surface overflow to the assigned output. The slide animation is
  unchanged on single-monitor setups.
- **Escape and click-outside now dismiss on first open** (#7). Removed the
  `focusedSinceShow` guard that, on KWin Wayland, blocked dismissal until the
  drawer had been clicked once to receive keyboard focus. All three close paths
  (Armoury Crate button, Escape, click-outside) now work immediately.

### Maintenance

- Dependency updates and documentation cleanup. Minimum Go version is now 1.25.


## Checklist

- [x] `make build` passes
- [x] `make lint` passes
- [x] `go test ./internal/theme/ -v` passes
- [x] Documentation updated if needed
