### PR TITLE
Debounce duplicate gui-toggle bursts

### DIFF
--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dahui/z13gui/internal/gui/gamescope"
 	"github.com/dahui/z13gui/internal/gui/layershell"
 	"github.com/dahui/z13gui/internal/theme"
+	"github.com/dahui/z13gui/internal/togglegate"
 	"github.com/diamondburned/gotk4/pkg/gdk/v4"
 	"github.com/diamondburned/gotk4/pkg/glib/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
@@ -31,18 +32,22 @@ var defaultThemeCSS string
 //go:embed theme-default.toml
 var defaultThemeTOML string
 
-const drawerWidth = 320 // drawer panel width in pixels
+const (
+	drawerWidth          = 320 // drawer panel width in pixels
+	daemonToggleDebounce = 250 * time.Millisecond
+)
 
 // Window is the overlay drawer. All methods must be called from the GTK main
 // thread except subscribeLoop, which runs in a background goroutine.
 type Window struct {
-	win       *gtk.ApplicationWindow
-	gtkWin    *gtk.Window // alias for backend calls
-	backend   Backend     // display backend (layer-shell or gamescope)
-	gamescope bool        // true when running under gamescope (X11 overlay mode)
-	state     *api.State  // latest daemon state; nil until first successful fetch
-	tab       string      // active device tab: "keyboard" or "lightbar"
-	visible   bool        // true when the drawer is on-screen or animating in
+	win              *gtk.ApplicationWindow
+	gtkWin           *gtk.Window // alias for backend calls
+	backend          Backend     // display backend (layer-shell or gamescope)
+	gamescope        bool        // true when running under gamescope (X11 overlay mode)
+	state            *api.State  // latest daemon state; nil until first successful fetch
+	tab              string      // active device tab: "keyboard" or "lightbar"
+	visible          bool        // true when the drawer is on-screen or animating in
+	lastDaemonToggle time.Time   // last accepted gui-toggle event from the daemon; suppresses duplicate bursts
 
 	swatchProvider *gtk.CSSProvider // dynamic swatch background colors
 	themeProvider  *gtk.CSSProvider // current theme; replaced on applyTheme()
@@ -79,16 +84,16 @@ type Window struct {
 	tdpPL3Label        *gtk.Label
 	tdpWarningLabel    *gtk.Label
 	fanCurve           *fanCurveEditor
-	saveTdpBtn  *gtk.Button
-	saveFanBtn  *gtk.Button
-	saveBothBtn *gtk.Button
-	resetTdpBtn *gtk.Button
-	resetFanBtn *gtk.Button
-	uvBox       *gtk.Box    // undervolt container, hidden when unavailable
-	uvCpuScale  *gtk.Scale
-	uvCpuLabel  *gtk.Label
-	saveUvBtn   *gtk.Button
-	resetUvBtn  *gtk.Button
+	saveTdpBtn         *gtk.Button
+	saveFanBtn         *gtk.Button
+	saveBothBtn        *gtk.Button
+	resetTdpBtn        *gtk.Button
+	resetFanBtn        *gtk.Button
+	uvBox              *gtk.Box // undervolt container, hidden when unavailable
+	uvCpuScale         *gtk.Scale
+	uvCpuLabel         *gtk.Label
+	saveUvBtn          *gtk.Button
+	resetUvBtn         *gtk.Button
 	headerTelemetry    *gtk.Label // "45°C · 3200 RPM" in main header
 	telemetryTempLabel *gtk.Label
 	telemetryFanLabel  *gtk.Label
@@ -366,14 +371,22 @@ func (w *Window) subscribeLoop() {
 		slog.Info("daemon connected")
 		backoff = time.Second
 		for event := range ch {
-			if event == "gui-toggle" {
-				slog.Debug("gui-toggle received, dispatching")
-				glib.TimeoutAdd(0, func() bool {
-					w.Toggle()
-					return false
-				})
-				glib.MainContextDefault().Wakeup()
+			if event != "gui-toggle" {
+				continue
 			}
+			receivedAt := time.Now()
+			lastAccepted, ok := togglegate.Accept(w.lastDaemonToggle, receivedAt, daemonToggleDebounce)
+			if !ok {
+				slog.Warn("gui-toggle suppressed", "since", receivedAt.Sub(w.lastDaemonToggle))
+				continue
+			}
+			w.lastDaemonToggle = lastAccepted
+			slog.Debug("gui-toggle received, dispatching")
+			glib.TimeoutAdd(0, func() bool {
+				w.Toggle()
+				return false
+			})
+			glib.MainContextDefault().Wakeup()
 		}
 		cancel()
 	}

--- a/internal/togglegate/togglegate.go
+++ b/internal/togglegate/togglegate.go
@@ -1,0 +1,13 @@
+package togglegate
+
+import "time"
+
+// Accept suppresses duplicate gui-toggle bursts.
+// A single physical Armoury Crate button press has been observed to reach the
+// GUI twice within the same instant; keep the first event and drop the burst.
+func Accept(last, now time.Time, window time.Duration) (time.Time, bool) {
+	if !last.IsZero() && now.Sub(last) < window {
+		return last, false
+	}
+	return now, true
+}

--- a/internal/togglegate/togglegate_test.go
+++ b/internal/togglegate/togglegate_test.go
@@ -1,0 +1,31 @@
+package togglegate
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAcceptAllowsFirstEvent(t *testing.T) {
+	acceptedAt, ok := Accept(time.Time{}, time.Unix(100, 0), 250*time.Millisecond)
+	if !ok {
+		t.Fatal("first daemon toggle should be accepted")
+	}
+	if acceptedAt.IsZero() {
+		t.Fatal("accepted timestamp should be recorded")
+	}
+}
+
+func TestAcceptSuppressesBurst(t *testing.T) {
+	base := time.Unix(100, 0)
+
+	acceptedAt, ok := Accept(time.Time{}, base, 250*time.Millisecond)
+	if !ok {
+		t.Fatal("first daemon toggle should be accepted")
+	}
+	if _, ok := Accept(acceptedAt, base.Add(100*time.Millisecond), 250*time.Millisecond); ok {
+		t.Fatal("duplicate burst should be suppressed")
+	}
+	if _, ok := Accept(acceptedAt, base.Add(300*time.Millisecond), 250*time.Millisecond); !ok {
+		t.Fatal("toggle after debounce window should be accepted")
+	}
+}


### PR DESCRIPTION
## Summary

Debounce duplicate `gui-toggle` bursts before they reach `w.Toggle()`.

## Changes

- add a small `internal/togglegate` helper to suppress immediate duplicate daemon toggle events
- debounce `gui-toggle` events in `subscribeLoop()` with a 250 ms window
- add pure unit tests for the debounce helper

## Testing

- `make build`
- `make lint`
- `make test`
- `go test ./internal/togglegate -count=1`
- Manual hardware validation on an ASUS ROG Flow Z13: the drawer now hides correctly when the Armoury Crate button is pressed again after previously getting stuck visible

## Checklist

- [x] `make build` passes
- [x] `make lint` passes
- [x] `go test ./internal/theme/ -v` passes
- [ ] Documentation updated if needed
